### PR TITLE
Fixes #1

### DIFF
--- a/AceJump.py
+++ b/AceJump.py
@@ -202,5 +202,5 @@ class JumpToPlaceCommand(sublime_plugin.TextCommand):
 	def run(self, edit, start):
 		# Should I do checking for correct number?
 		self.view.sel().clear()
-		self.view.sel().add(sublime.Region(start))
-		self.view.show(start)
+		self.view.sel().add(sublime.Region(long(start)))
+		self.view.show(long(start))

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,0 +1,3 @@
+[
+	{ "keys": ["super+ctrl+;"], "command": "ace_jump" }
+]


### PR DESCRIPTION
This fixes the issue where the cursor does not get placed within the editor after hitting enter.

However, the word select modifier isn't working but with this update this plugin is now usable with OSX!
